### PR TITLE
Allow multiple separators

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    change_the_subject (0.1.0)
+    change_the_subject (0.2.0)
       yaml
 
 GEM
@@ -79,4 +79,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.3.18
+   2.3.22

--- a/lib/change_the_subject.rb
+++ b/lib/change_the_subject.rb
@@ -6,18 +6,18 @@ require "yaml"
 class ChangeTheSubject
   class Error < StandardError; end
 
-  def self.fix(subject_terms:, separator: nil)
-    new(separator: separator).fix(subject_terms: subject_terms)
+  def self.fix(subject_terms:, separators: nil)
+    new(separators: separators).fix(subject_terms: subject_terms)
   end
 
-  def self.check_for_replacement(term:, separator: nil)
-    new(separator: separator).check_for_replacement(term: term)
+  def self.check_for_replacement(term:, separators: nil)
+    new(separators: separators).check_for_replacement(term: term)
   end
 
-  attr_reader :separator
+  attr_reader :separators
 
-  def initialize(separator: nil)
-    @separator = separator || "—"
+  def initialize(separators: nil)
+    @separators = separators || ["—"]
   end
 
   def terms_mapping
@@ -44,14 +44,18 @@ class ChangeTheSubject
   # @param [String] term
   # @return [String]
   def check_for_replacement(term:)
-    subterms = term.split(separator)
-    subfield_a = subterms.first
-    replacement = terms_mapping[subfield_a]
-    return term unless replacement
+    separators.each do |separator|
+      subterms = term.split(separator)
+      subfield_a = subterms.first
+      replacement = terms_mapping[subfield_a]
+      next unless replacement
 
-    subterms.delete(subfield_a)
-    subterms.prepend(replacement["replacement"])
-    subterms.join(separator)
+      subterms.delete(subfield_a)
+      subterms.prepend(replacement["replacement"])
+      return subterms.join(separator)
+    end
+
+    term
   end
 
   private

--- a/spec/change_the_subject_spec.rb
+++ b/spec/change_the_subject_spec.rb
@@ -92,30 +92,24 @@ RSpec.describe ChangeTheSubject do
     end
   end
 
-  context "Indigenous studies terms" do
+  context "with a subject term with a default separator" do
     let(:subject_terms) { ["Indians of North America—Connecticut"] }
     let(:fixed_subject_terms) { ["Indigenous peoples of North America—Connecticut"] }
 
-    it "suggests a replacement" do
+    it "uses correct separators" do
       expect(described_class.fix(subject_terms: subject_terms)).to eq fixed_subject_terms
     end
   end
 
-  context "with the default separator" do
-    let(:subject_terms) { ["Indians of North America—Connecticut"] }
-    let(:fixed_subject_terms) { ["Indigenous peoples of North America—Connecticut"] }
-
-    it "uses correct separator" do
-      expect(described_class.fix(subject_terms: subject_terms)).to eq fixed_subject_terms
+  context "with alternate separators" do
+    let(:subject_terms) do
+      ["Indians of North America || Connecticut",
+       "Indians of North America — New York"]
     end
-  end
+    let(:fixed_subject_terms) { ["Indigenous peoples of North America || Connecticut", "Indigenous peoples of North America — New York"] }
 
-  context "with an alternate separator" do
-    let(:subject_terms) { ["Indians of North America || Connecticut"] }
-    let(:fixed_subject_terms) { ["Indigenous peoples of North America || Connecticut"] }
-
-    it "uses correct separator" do
-      expect(described_class.fix(subject_terms: subject_terms, separator: " || ")).to eq fixed_subject_terms
+    it "uses correct separators" do
+      expect(described_class.fix(subject_terms: subject_terms, separators: [" || ", " — "])).to eq fixed_subject_terms
     end
   end
 


### PR DESCRIPTION
Fixes issue in Pulfalight where we have multiple separator types in the metadata.

See: https://github.com/pulibrary/pulfalight/issues/1139