### PR TITLE
[#30] Add configuration to replace euphemistic Japanese Americans—Evacuation and relocation

### DIFF
--- a/config/change_the_subject.yml
+++ b/config/change_the_subject.yml
@@ -94,3 +94,7 @@
 "Gays":
   replacement: "Gay people"
   rationale: "This subject heading has been updated by the Library of Congress, but some partner records have not yet been updated to reflect this."
+# The following term will match if the first two subfields in the field are "Japanese Americans" and "Evacuation and relocation, 1942-1945"
+["Japanese Americans", "Evacuation and relocation, 1942-1945"]:
+  replacement: ["Japanese Americans", "Forced removal and internment, 1942-1945"]
+  rationale: "This subject heading has been updated by the Library of Congress, but some partner records have not yet been updated to reflect this."

--- a/lib/change_the_subject.rb
+++ b/lib/change_the_subject.rb
@@ -46,19 +46,37 @@ class ChangeTheSubject
   def check_for_replacement(term:)
     separators.each do |separator|
       subterms = term.split(separator)
-      subfield_a = subterms.first
-      replacement = terms_mapping[subfield_a]
+      replacement = replacement_config_for_subterms(subterms)
       next unless replacement
 
-      subterms.delete(subfield_a)
-      subterms.prepend(replacement["replacement"])
-      return subterms.join(separator)
+      new_terms = replacement_terms(replacement)
+      return subterms.drop(new_terms.count)
+                     .prepend(new_terms)
+                     .join(separator)
     end
 
     term
   end
 
   private
+
+  def replacement_config_for_subterms(subterms)
+    matching_key = terms_mapping.keys.find do |term_to_replace|
+      term_matches_subterms?(term_to_replace, subterms)
+    end
+    return terms_mapping[matching_key] if matching_key
+  end
+
+  def term_matches_subterms?(term, subterms)
+    term_as_array = Array(term)
+    term_as_array.count.times.all? do |index|
+      term_as_array[index] == subterms[index]
+    end
+  end
+
+  def replacement_terms(configured_term)
+    Array(configured_term["replacement"])
+  end
 
   def config
     @config ||= config_yaml

--- a/spec/change_the_subject_spec.rb
+++ b/spec/change_the_subject_spec.rb
@@ -71,6 +71,33 @@ RSpec.describe ChangeTheSubject do
     end
   end
 
+  context "when the original term spans multiple subfields" do
+    let(:subject_terms) { ["Japanese Americans—Evacuation and relocation, 1942-1945", "Music"] }
+    let(:fixed_subject_terms) { ["Japanese Americans—Forced removal and internment, 1942-1945", "Music"] }
+
+    it "changes all of the configured subfields" do
+      expect(described_class.fix(subject_terms: subject_terms)).to eq fixed_subject_terms
+    end
+
+    context "when the subject term has further subdivisions after the configured term" do
+      let(:subject_terms) { ["Japanese Americans—Evacuation and relocation, 1942-1945—Comic books, strips, etc."] }
+      let(:fixed_subject_terms) { ["Japanese Americans—Forced removal and internment, 1942-1945—Comic books, strips, etc."] }
+
+      it "changes only the first, configured subfields" do
+        expect(described_class.fix(subject_terms: subject_terms)).to eq fixed_subject_terms
+      end
+    end
+
+    context "when the subject term is not at the beginning of the string" do
+      let(:subject_terms) { ["Some initial subject heading—Japanese Americans—Evacuation and relocation, 1942-1945"] }
+      let(:fixed_subject_terms) { ["Some initial subject heading—Japanese Americans—Evacuation and relocation, 1942-1945"] }
+
+      it "makes no attempt to change the subject" do
+        expect(described_class.fix(subject_terms: subject_terms)).to eq fixed_subject_terms
+      end
+    end
+  end
+
   context "subject terms with both the original and mapped term" do
     let(:subject_terms) { ["Illegal aliens", "Undocumented immigrants"] }
     let(:fixed_subject_terms) { ["Undocumented immigrants"] }


### PR DESCRIPTION
This is the first configuration in this gem to match on multiple MARC subfields.

Closes #30 